### PR TITLE
Update document version (semi-automatically)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # the Doc Template for RISC-V Extensions.
 
 DATE ?= $(shell date +%Y-%m-%d)
-VERSION ?= v0.0.0
+VERSION ?= $(shell git describe --tag --always --dirty)
 REVMARK ?= Draft
 DOCKER_RUN := docker run --rm -v ${PWD}:/build -w /build \
 riscvintl/riscv-docs-base-container-image:latest


### PR DESCRIPTION
Though the documentation now passed version 0.9, the documentation itself says it's still version 0.0.0.
(I'm not sure about the status of this document; if this is Frozen, `REVMARK` variable below may be changed)

This PR partially introduces a technique from riscv/riscv-zicond.  Even if this PR is not suitable for your repository, I hope that the documentation is properly versioned.